### PR TITLE
AM-2639 Adjust primary springBoot version in PR-1785

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ def versions = [
   reformS2sClient: '4.0.2',
   serenity       : '2.2.12',
   sonarPitest    : '0.5',
-  springBoot     : '2.6.3',
+  springBoot     : '2.6.6',
   spring         : '5.3.25',
   springSecurity : '5.7.8',
   springHystrix  : '2.1.1.RELEASE',


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [AM-2639](https://tools.hmcts.net/jira/browse/AM-2639) _"Upgrade Spring Boot version for RAS service"_

### Change description ###

Bump primary springBoot version in #1785 back to 2.6.6 to match `master` branch.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
