### PR TITLE
AM-2888 CVE-2023-34034 Fix spring-security upgraded 5.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def versions = [
   sonarPitest    : '0.5',
   springBoot     : '2.7.12',
   spring         : '5.3.27',
-  springSecurity : '5.7.8',
+  springSecurity : '5.7.10',
   springHystrix  : '2.1.1.RELEASE',
   swagger2Version: '2.10.5',
   pact_version   : '4.1.7',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,8 +9,4 @@
     <notes>https://tools.hmcts.net/jira/browse/AM-2839 jackson-databind</notes>
     <cve>CVE-2023-35116</cve>
   </suppress>
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/AM-2888 spring-security</notes>
-    <cve>CVE-2023-34034</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2888
CVE-2023-34034 Fix spring-security upgraded 5.7.10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
