### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def versions = [
   lombok         : '1.18.28',
   gradlePitest   : '1.3.0',
   pitest         : '1.13.1',
-  reformLogging  : '5.1.9',
+  reformLogging  : '6.0.1',
   reformS2sClient: '4.0.2',
   serenity       : '2.2.12',
   sonarPitest    : '0.5',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.