### PR TITLE
AM-2941 Move away from using `Docker.io` for images referenced by AM …

### DIFF
--- a/charts/am-role-assignment-service/Chart.yaml
+++ b/charts/am-role-assignment-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Role Assignment Service
 name: am-role-assignment-service
 home: https://github.com/hmcts/am-role-assignment-service
-version: 0.0.66
+version: 0.0.67
 maintainers:
   - name: Access Management Team
 dependencies:

--- a/charts/am-role-assignment-service/Chart.yaml
+++ b/charts/am-role-assignment-service/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: Access Management Team
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 4.2.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2941
Move away from using `Docker.io` for images referenced by AM - chart-java version bumped to 4.2.0 to pull hmcts postgres image

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
