### PR TITLE
AM-2995 Provision Terraform Postgres v15 - subnet_suffix = "expanded"

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -126,6 +126,9 @@ module "role-assignment-database-v15" {
   common_tags        = var.common_tags
   pgsql_version      = "15"
 
+  # The original subnet is full, this is required to use the new subnet for new databases
+  subnet_suffix = "expanded"
+
   pgsql_databases = [
       {
         name = var.database_name


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2995
Provision Terraform Postgres v15 - subnet_suffix = "expanded"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
