### PR TITLE
AM-3068 Pitest failures in Nightly - pitest-junit5-plugin upgraded to…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
   dependencies {
     classpath("net.serenity-bdd:serenity-gradle-plugin:2.4.34")
-    classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.7.4'
+    classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.15.0'
   }
 }
 
@@ -19,7 +19,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.4'
   id 'org.springframework.boot' version '2.7.17'
-  id 'info.solidsoft.pitest' version '1.7.4'
+  id 'info.solidsoft.pitest' version '1.15.0'
   id 'com.github.ben-manes.versions' version '0.45.0' //do not update this version from 0.41.0
   id 'org.sonarqube' version '4.0.0.2929'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.25'
@@ -41,7 +41,7 @@ def versions = [
   junit          : '5.9.0',
   lombok         : '1.18.30',
   gradlePitest   : '1.3.0',
-  pitest         : '1.13.1',
+  pitest         : '1.15.3',
   reformLogging  : '6.0.1',
   reformS2sClient: '4.0.2',
   serenity       : '2.2.12',
@@ -466,7 +466,7 @@ dependencies {
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
   testImplementation group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.9.1'
   testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
-  testImplementation group: 'info.solidsoft.gradle.pitest', name:'gradle-pitest-plugin', version: '1.7.4'
+  testImplementation group: 'info.solidsoft.gradle.pitest', name:'gradle-pitest-plugin', version: '1.15.0'
   testImplementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
   testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: versions.springSecurity
   testImplementation group: 'org.springframework.boot', name:'spring-boot-starter-test', version: versions.springBoot
@@ -504,7 +504,7 @@ dependencies {
 
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-  implementation group: 'org.pitest', name: 'pitest-junit5-plugin', version: '0.16'
+  implementation group: 'org.pitest', name: 'pitest-junit5-plugin', version: '1.2.1'
 
   contractTestRuntime group:"org.junit.jupiter", name:"junit-jupiter-engine", version: versions.junit
   contractTestImplementation group: "org.junit.jupiter", name:"junit-jupiter-api", version: versions.junit


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3068
Pitest failures in Nightly - pitest-junit5-plugin upgraded to 1.2.1 allowing other pitest components to be upgraded to 1.15.x

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
