### PR TITLE
DTSAM-185 CVE-2024-1597 postgresql upgraded to 42.6.1, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -437,7 +437,7 @@ dependencies {
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcat
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.15.Final'
   implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.8'
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.1'
   implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'commons-io', name:'commons-io', version: '2.15.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,8 +8,4 @@
     <notes>https://tools.hmcts.net/jira/browse/DTSAM-90 plexus</notes>
     <cve>CVE-2022-4245</cve>
   </suppress>
-  <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/DTSAM-185 postgresql_jdbc_driver</notes>
-    <cve>CVE-2024-1597</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-185
CVE-2024-1597 postgresql upgraded to 42.6.1, suppression removed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
