### PR TITLE
DTSPO-17373 Jenkins Build Failed at Security Scan stage, Zap image up…

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,7 +11,7 @@ properties([
   ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@test-new-zap-image")
 
 def type = "java"
 def product = "am"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-17373
Jenkins Build Failed at Security Scan stage, 
Zap image updated with new version to test the nightly build

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
