### PR TITLE
DTSAM-322 Decommission custom Postgres-V15 key vault values now that …

### DIFF
--- a/charts/am-role-assignment-service/Chart.yaml
+++ b/charts/am-role-assignment-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Role Assignment Service
 name: am-role-assignment-service
 home: https://github.com/hmcts/am-role-assignment-service
-version: 0.0.78
+version: 0.0.79
 maintainers:
   - name: Access Management Team
 dependencies:

--- a/charts/am-role-assignment-service/values.yaml
+++ b/charts/am-role-assignment-service/values.yaml
@@ -12,11 +12,11 @@ java:
       secrets:
         - name: am-role-assignment-service-s2s-secret
           alias: AM_ROLE_ASSIGNMENT_SERVICE_SECRET
-        - name: role-assignment-service-POSTGRES-PASS-V15
+        - name: role-assignment-service-POSTGRES-PASS
           alias: ROLE_ASSIGNMENT_DB_PASSWORD
-        - name: role-assignment-service-POSTGRES-USER-V15
+        - name: role-assignment-service-POSTGRES-USER
           alias: ROLE_ASSIGNMENT_DB_USERNAME
-        - name: role-assignment-service-POSTGRES-HOST-V15
+        - name: role-assignment-service-POSTGRES-HOST
           alias: ROLE_ASSIGNMENT_DB_HOST
         - name: app-insights-connection-string
           alias: app-insights-connection-string


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-322
Decommission custom Postgres-V15 key vault values now that the standard ones are pointing to V15 instance

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
