### PR TITLE
DTSAM-379 canIDeploy Index 0 out of bounds for length 0 Issue - comma…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,11 +201,8 @@ task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verificatio
 }
 
 project.ext {
-  pacticipantVersion = getCheckedOutGitCommitHash()
-}
-
-static def getCheckedOutGitCommitHash() {
-  'git rev-parse --verify --short HEAD'.execute().text.trim()
+  // DTSAM-379 canIDeploy Index 0 out of bounds for length 0 Issue
+  pacticipantVersion = System.env.GIT_COMMIT.substring(0,9)
 }
 
 task contract(type: Test) {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-379
canIDeploy Index 0 out of bounds for length 0 Issue - command line git to get commit hash replaced with system env var substring

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
