### PR TITLE
DTSAM-860 privatelaw_wa_1_7 - Enable Civil judge to access FL401 case…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/roleassignment/controller/RoleAssignmentIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/roleassignment/controller/RoleAssignmentIntegrationTest.java
@@ -250,7 +250,7 @@ public class RoleAssignmentIntegrationTest extends BaseTest {
         List<RoleConfigRole> roleConfigRoles = mapper.readValue(response, new TypeReference<>() {
         });
 
-        assertEquals(200, roleConfigRoles.size());
+        assertEquals(201, roleConfigRoles.size());
         for (RoleConfigRole roleConfigRole : roleConfigRoles) {
             assertNotNull(roleConfigRole.getName());
             assertNotNull(roleConfigRole.getCategory());

--- a/src/main/resources/roleconfig/role_privatelaw.json
+++ b/src/main/resources/roleconfig/role_privatelaw.json
@@ -33,5 +33,35 @@
         }
       }
     ]
+  },
+  {
+    "name": "fl401-judge",
+    "label": "FL401 Judge",
+    "description": "FL401 Judge role for judicial users",
+    "category": "JUDICIAL",
+    "substantive": true,
+    "type": "ORGANISATION",
+    "patterns": [
+      {
+        "roleType": {
+          "mandatory": true,
+          "values": ["ORGANISATION"]
+        },
+        "grantType": {
+          "mandatory": true,
+          "values": ["STANDARD"]
+        },
+        "classification": {
+          "mandatory": true,
+          "values": ["PUBLIC"]
+        },
+        "attributes": {
+          "jurisdiction": {
+            "mandatory": true,
+            "values": ["PRIVATELAW"]
+          }
+        }
+      }
+    ]
   }
 ]

--- a/src/test/java/uk/gov/hmcts/reform/roleassignment/domain/service/drools/AllServicesOrgRoleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/roleassignment/domain/service/drools/AllServicesOrgRoleTest.java
@@ -521,7 +521,8 @@ class AllServicesOrgRoleTest extends DroolBase {
         "caseworker-privatelaw-externaluser-viewonly,OTHER_GOV_DEPT,STANDARD,north-east,PRIVATELAW,UK,ORGANISATION,"
             + "N,Null,PUBLIC",
         "listed-hearing-viewer,OTHER_GOV_DEPT,STANDARD,north-east,PRIVATELAW,UK,ORGANISATION,N,Null,PUBLIC",
-        "wlu-admin,ADMIN,STANDARD,south-east,CIVIL,UK,ORGANISATION,Y,Null,PUBLIC"
+        "wlu-admin,ADMIN,STANDARD,south-east,CIVIL,UK,ORGANISATION,Y,Null,PUBLIC",
+        "fl401-judge,JUDICIAL,STANDARD,south-east,PRIVATELAW,UK,ORGANISATION,Y,Null,PUBLIC"
     })
     void shouldApproveRequestedRoleForOrg(String roleName, String roleCategory, String grantType,
                                           String region, String jurisdiction, String primaryLocation,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSAM-860

### Change description ###

privatelaw_wa_1_7 - Enable Civil judge to access FL401 cases for Private Law

> NB: This PR is a dependency of: hmcts/am-org-role-mapping-service#2335.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[* ] No
```
