### PR TITLE
DTSAM-1103 FTAs for ccd-data-store case-role delete

### DIFF
--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026.feature
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026.feature
@@ -1,0 +1,102 @@
+@F-026
+@FeatureToggle(EV:AZURE_CASE_VALIDATION_FTA_ENABLED=on)
+Feature: F-026 : CCD Data Store deletion tests
+
+  Background:
+    Given an appropriate test context as detailed in the test data source
+
+  @S-026.01
+  Scenario: must successfully allow CCD-Data-Store to delete CITIZEN case-roles
+    Given a user with [an active IDAM profile with full permissions],
+    And a user [Befta3 - who is the actor for requested role],
+    And a successful call [to create a case-role assignment for a Citizen] as in [S-026.01_CreateCaseRole_CITIZEN],
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    When a request is prepared with appropriate values,
+    And the request [with S2S token for CCD-Data-Store service],
+    And the request [with process and reference values used to create the case-role assignment],
+    And it is submitted to call the [Delete Role Assignments by Process] operation of [Role Assignment Service],
+    Then a positive response is received,
+    And the response has all other details as expected,
+    And a successful call [to check no case role assignments are found for the actor] as in [F-026_CheckCaseRole__NotFound].
+
+  @S-026.02
+  Scenario: must successfully allow CCD-Data-Store to delete PROFESSIONAL case-roles
+    Given a user with [an active IDAM profile with full permissions],
+    And a user [Befta3 - who is the actor for requested role],
+    And a successful call [to create a case-role assignment for a Professional] as in [S-026.02_CreateCaseRole_PROFESSIONAL],
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    When a request is prepared with appropriate values,
+    And the request [with S2S token for CCD-Data-Store service],
+    And the request [with process and reference values used to create the case-role assignment],
+    And it is submitted to call the [Delete Role Assignments by Process] operation of [Role Assignment Service],
+    Then a positive response is received,
+    And the response has all other details as expected,
+    And a successful call [to check no case role assignments are found for the actor] as in [F-026_CheckCaseRole__NotFound].
+
+  @S-026.03
+  Scenario: must reject call from CCD-Data-Store to delete ADMIN case-roles
+    Given a user with [an active IDAM profile with full permissions],
+    And a user [Befta3 - who is the actor for requested role],
+    And a successful call [to create org role assignments for actor (ADMIN) & requester (case-allocator)] as in [S-026.03_CreateOrgRoles_ADMIN],
+    And a successful call [to create a case-role assignment for an Admin] as in [S-026.03_CreateCaseRole_ADMIN],
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    When a request is prepared with appropriate values,
+    And the request [with S2S token for CCD-Data-Store service],
+    And the request [with process and reference values used to create the case-role assignment],
+    And it is submitted to call the [Delete Role Assignments by Process] operation of [Role Assignment Service],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    And a successful call [to delete case role assignments just created above] as in [F-026_DeleteCaseRoles],
+    And a successful call [to delete org role assignments just created above] as in [F-026_DeleteOrgRoles].
+
+  @S-026.04
+  Scenario: must reject call from CCD-Data-Store to delete CTSC case-roles
+    Given a user with [an active IDAM profile with full permissions],
+    And a user [Befta3 - who is the actor for requested role],
+    And a successful call [to create org role assignments for actor (CTSC) & requester (case-allocator)] as in [S-026.04_CreateOrgRoles_CTSC],
+    And a successful call [to create a case-role assignment for a CTSC] as in [S-026.04_CreateCaseRole_CTSC],
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    When a request is prepared with appropriate values,
+    And the request [with S2S token for CCD-Data-Store service],
+    And the request [with process and reference values used to create the case-role assignment],
+    And it is submitted to call the [Delete Role Assignments by Process] operation of [Role Assignment Service],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    And a successful call [to delete case role assignments just created above] as in [F-026_DeleteCaseRoles],
+    And a successful call [to delete org role assignments just created above] as in [F-026_DeleteOrgRoles].
+
+  @S-026.05
+  Scenario: must reject call from CCD-Data-Store to delete LEGAL_OPS case-roles
+    Given a user with [an active IDAM profile with full permissions],
+    And a user [Befta3 - who is the actor for requested role],
+    And a successful call [to create org role assignments for actor (LEGAL_OPS) & requester (case-allocator)] as in [S-026.05_CreateOrgRoles_LEGAL_OPS],
+    And a successful call [to create a case-role assignment for a LEGAL_OPS] as in [S-026.05_CreateCaseRole_LEGAL_OPS],
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    When a request is prepared with appropriate values,
+    And the request [with S2S token for CCD-Data-Store service],
+    And the request [with process and reference values used to create the case-role assignment],
+    And it is submitted to call the [Delete Role Assignments by Process] operation of [Role Assignment Service],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    And a successful call [to delete case role assignments just created above] as in [F-026_DeleteCaseRoles],
+    And a successful call [to delete org role assignments just created above] as in [F-026_DeleteOrgRoles].
+
+  @S-026.06
+  Scenario: must reject call from CCD-Data-Store to delete JUDICIAL case-roles
+    Given a user with [an active IDAM profile with full permissions],
+    And a user [Befta3 - who is the actor for requested role],
+    And a successful call [to create org role assignments for actor (JUDICIAL) & requester (case-allocator)] as in [S-026.06_CreateOrgRoles_JUDICIAL],
+    And a successful call [to create a case-role assignment for JUDICIAL] as in [S-026.06_CreateCaseRole_JUDICIAL],
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    When a request is prepared with appropriate values,
+    And the request [with S2S token for CCD-Data-Store service],
+    And the request [with process and reference values used to create the case-role assignment],
+    And it is submitted to call the [Delete Role Assignments by Process] operation of [Role Assignment Service],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to check case role assignments are found for the actor] as in [F-026_CheckCaseRole__Found],
+    And a successful call [to delete case role assignments just created above] as in [F-026_DeleteCaseRoles],
+    And a successful call [to delete org role assignments just created above] as in [F-026_DeleteOrgRoles].

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_CheckCaseRole__Found.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_CheckCaseRole__Found.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "F-026_CheckCaseRole__Found",
+  "_extends_": "F-025_CheckCaseRole__Found"
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_CheckCaseRole__NotFound.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_CheckCaseRole__NotFound.td.json
@@ -1,0 +1,5 @@
+{
+  "_guid_": "F-026_CheckCaseRole__NotFound",
+  "_extends_": "F-025_CheckCaseRole__NotFound"
+}
+

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_DeleteCaseRoles.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_DeleteCaseRoles.td.json
@@ -1,0 +1,25 @@
+{
+  "_guid_": "F-026_DeleteCaseRoles",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "to delete case role assignments just created above"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser4"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForOrm]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][parentContext][testData][request][pathVariables][process]}",
+      "reference": "F-026_CreateCaseRole"
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_DeleteCaseRoles.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_DeleteCaseRoles.td.json
@@ -14,7 +14,7 @@
 
   "request": {
     "headers": {
-      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForOrm]}"
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForXui]}"
     },
     "pathVariables": {
       "process": "${[scenarioContext][parentContext][testData][request][pathVariables][process]}",

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_DeleteOrgRoles.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/F-026_DeleteOrgRoles.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "F-026_DeleteOrgRoles",
+  "_extends_": "F-025_DeleteOrgRoles",
+
+  "request": {
+    "pathVariables": {
+      "reference": "F-026_CreateOrgRole"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.01.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.01.td.json
@@ -1,0 +1,34 @@
+{
+  "title": "must reject call from CCD-Data-Store to delete CITIZEN case-roles",
+
+  "_guid_": "S-026.01",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "an active IDAM profile with full permissions",
+    "Befta3 - who is the actor for requested role",
+
+    "with S2S token for CCD-Data-Store service",
+    "with process and reference values used to create the case-role assignment"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser2"
+    }, 
+    "befta3": {
+      "_extends_": "AmBeftaUser3"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForCcd]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][childContexts][S-026.01_CreateCaseRole_CITIZEN][testData][request][body][roleRequest][process]}",
+      "reference": "${[scenarioContext][childContexts][S-026.01_CreateCaseRole_CITIZEN][testData][request][body][roleRequest][reference]}"
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.01_CreateCaseRole_CITIZEN.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.01_CreateCaseRole_CITIZEN.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.01_CreateCaseRole_CITIZEN",
+  "_extends_": "S-025.01_CreateCaseRole_CITIZEN",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateCaseRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.02.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.02.td.json
@@ -1,0 +1,34 @@
+{
+  "title": "must reject call from CCD-Data-Store to delete PROFESSIONAL case-roles",
+
+  "_guid_": "S-026.02",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "an active IDAM profile with full permissions",
+    "Befta3 - who is the actor for requested role",
+
+    "with S2S token for CCD-Data-Store service",
+    "with process and reference values used to create the case-role assignment"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser2"
+    }, 
+    "befta3": {
+      "_extends_": "AmBeftaUser3"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForCcd]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][childContexts][S-026.02_CreateCaseRole_PROFESSIONAL][testData][request][body][roleRequest][process]}",
+      "reference": "${[scenarioContext][childContexts][S-026.02_CreateCaseRole_PROFESSIONAL][testData][request][body][roleRequest][reference]}"
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.02_CreateCaseRole_PROFESSIONAL.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.02_CreateCaseRole_PROFESSIONAL.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.02_CreateCaseRole_PROFESSIONAL",
+  "_extends_": "S-025.02_CreateCaseRole_PROFESSIONAL",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateCaseRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.03.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.03.td.json
@@ -1,0 +1,38 @@
+{
+  "title": "must reject call from CCD-Data-Store to delete ADMIN case-roles",
+
+  "_guid_": "S-026.03",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "an active IDAM profile with full permissions",
+    "Befta3 - who is the actor for requested role",
+
+    "with S2S token for CCD-Data-Store service",
+    "with process and reference values used to create the case-role assignment"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser2"
+    }, 
+    "befta3": {
+      "_extends_": "AmBeftaUser3"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForCcd]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][childContexts][S-026.03_CreateCaseRole_ADMIN][testData][request][body][roleRequest][process]}",
+      "reference": "${[scenarioContext][childContexts][S-026.03_CreateCaseRole_ADMIN][testData][request][body][roleRequest][reference]}"
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "RAS_422_Response"
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.03_CreateCaseRole_ADMIN.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.03_CreateCaseRole_ADMIN.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.03_CreateCaseRole_ADMIN",
+  "_extends_": "S-025.03_CreateCaseRole_ADMIN",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateCaseRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.03_CreateOrgRoles_ADMIN.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.03_CreateOrgRoles_ADMIN.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.03_CreateOrgRoles_ADMIN",
+  "_extends_": "S-025.03_CreateOrgRoles_ADMIN",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateOrgRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.04.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.04.td.json
@@ -1,0 +1,38 @@
+{
+  "title": "must reject call from CCD-Data-Store to delete CTSC case-roles",
+
+  "_guid_": "S-026.04",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "an active IDAM profile with full permissions",
+    "Befta3 - who is the actor for requested role",
+
+    "with S2S token for CCD-Data-Store service",
+    "with process and reference values used to create the case-role assignment"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser2"
+    }, 
+    "befta3": {
+      "_extends_": "AmBeftaUser3"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForCcd]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][childContexts][S-026.04_CreateCaseRole_CTSC][testData][request][body][roleRequest][process]}",
+      "reference": "${[scenarioContext][childContexts][S-026.04_CreateCaseRole_CTSC][testData][request][body][roleRequest][reference]}"
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "RAS_422_Response"
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.04_CreateCaseRole_CTSC.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.04_CreateCaseRole_CTSC.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.04_CreateCaseRole_CTSC",
+  "_extends_": "S-025.04_CreateCaseRole_CTSC",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateCaseRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.04_CreateOrgRoles_CTSC.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.04_CreateOrgRoles_CTSC.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.04_CreateOrgRoles_CTSC",
+  "_extends_": "S-025.04_CreateOrgRoles_CTSC",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateOrgRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.05.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.05.td.json
@@ -1,0 +1,38 @@
+{
+  "title": "must reject call from CCD-Data-Store to delete LEGAL_OPS case-roles",
+
+  "_guid_": "S-026.05",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "an active IDAM profile with full permissions",
+    "Befta3 - who is the actor for requested role",
+
+    "with S2S token for CCD-Data-Store service",
+    "with process and reference values used to create the case-role assignment"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser2"
+    }, 
+    "befta3": {
+      "_extends_": "AmBeftaUser3"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForCcd]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][childContexts][S-026.05_CreateCaseRole_LEGAL_OPS][testData][request][body][roleRequest][process]}",
+      "reference": "${[scenarioContext][childContexts][S-026.05_CreateCaseRole_LEGAL_OPS][testData][request][body][roleRequest][reference]}"
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "RAS_422_Response"
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.05_CreateCaseRole_LEGAL_OPS.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.05_CreateCaseRole_LEGAL_OPS.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.05_CreateCaseRole_LEGAL_OPS",
+  "_extends_": "S-025.05_CreateCaseRole_LEGAL_OPS",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateCaseRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.05_CreateOrgRoles_LEGAL_OPS.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.05_CreateOrgRoles_LEGAL_OPS.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.05_CreateOrgRoles_LEGAL_OPS",
+  "_extends_": "S-025.05_CreateOrgRoles_LEGAL_OPS",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateOrgRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.06.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.06.td.json
@@ -1,0 +1,38 @@
+{
+  "title": "must reject call from CCD-Data-Store to delete JUDICIAL case-roles",
+
+  "_guid_": "S-026.06",
+  "_extends_": "DeleteDataForRoleAssignments",
+
+  "specs": [
+    "an active IDAM profile with full permissions",
+    "Befta3 - who is the actor for requested role",
+
+    "with S2S token for CCD-Data-Store service",
+    "with process and reference values used to create the case-role assignment"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "AmBeftaUser2"
+    }, 
+    "befta3": {
+      "_extends_": "AmBeftaUser3"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForCcd]}"
+    },
+    "pathVariables": {
+      "process": "${[scenarioContext][childContexts][S-026.06_CreateCaseRole_JUDICIAL][testData][request][body][roleRequest][process]}",
+      "reference": "${[scenarioContext][childContexts][S-026.06_CreateCaseRole_JUDICIAL][testData][request][body][roleRequest][reference]}"
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "RAS_422_Response"
+  }
+
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.06_CreateCaseRole_JUDICIAL.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.06_CreateCaseRole_JUDICIAL.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.06_CreateCaseRole_JUDICIAL",
+  "_extends_": "S-025.06_CreateCaseRole_JUDICIAL",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateCaseRole"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.06_CreateOrgRoles_JUDICIAL.td.json
+++ b/src/functionalTest/resources/features/F-026 - CCD Case Data Store deletion tests/S-026.06_CreateOrgRoles_JUDICIAL.td.json
@@ -1,0 +1,12 @@
+{
+  "_guid_": "S-026.06_CreateOrgRoles_JUDICIAL",
+  "_extends_": "S-025.06_CreateOrgRoles_JUDICIAL",
+
+  "request": {
+    "body": {
+      "roleRequest": {
+        "reference": "F-026_CreateOrgRole"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSAM-1103](https://tools.hmcts.net/jira/browse/DTSAM-1103) _"disposer_1_1 - Allow R&D Case Disposer to delete all categories of case-roles"_

### Change description ###

Creeate FTAs for ccd-data-store case-role delete

> NB: This is a PATCH PR for:
> * #2614

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
