### PR TITLE
DTSAM-1273 Disable PCS case-role FTAs until AAT instance is stable

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -88,6 +88,7 @@ env.PACT_BROKER_SCHEME = "https"
 
 // Var to turn FTAs that rely on the RAS-CCD case validation on/off, i.e. when CCD is not available.
 env.AZURE_CASE_VALIDATION_FTA_ENABLED = "true"
+env.PCS_CASE_VALIDATION_FTA_ENABLED = "false" // temporarily disabled until we have a stable PCS environment to run these tests against
 
 // Vars for Azure Container Registries DTSAM-370
 env.TESTCONTAINERS_HOST_OVERRIDE="localhost"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -93,6 +93,7 @@ withNightlyPipeline(type, product, component) {
 
   // Var to turn FTAs that rely on the RAS-CCD case validation on/off, i.e. when CCD is not available.
   env.AZURE_CASE_VALIDATION_FTA_ENABLED = "true"
+  env.PCS_CASE_VALIDATION_FTA_ENABLED = "false" // temporarily disabled until we have a stable PCS environment to run these tests against
 
   // Vars for Azure Container Registries DTSAM-370
   env.TESTCONTAINERS_HOST_OVERRIDE="localhost"

--- a/src/functionalTest/resources/features/F-021 - Create POSSESSIONS JUDICIAL Case Role Assignments/F-021.feature
+++ b/src/functionalTest/resources/features/F-021 - Create POSSESSIONS JUDICIAL Case Role Assignments/F-021.feature
@@ -1,5 +1,6 @@
 @F-021
 @FeatureToggle(EV:AZURE_CASE_VALIDATION_FTA_ENABLED=on)
+@FeatureToggle(EV:PCS_CASE_VALIDATION_FTA_ENABLED=on)
 Feature: F-021 : Create Case Role Assignments for POSSESSIONS JUDICIAL case roles
 
   Background:

--- a/src/functionalTest/resources/features/F-022 - Create POSSESSIONS STAFF Case Role Assignments/F-022.feature
+++ b/src/functionalTest/resources/features/F-022 - Create POSSESSIONS STAFF Case Role Assignments/F-022.feature
@@ -1,5 +1,6 @@
 @F-022
 @FeatureToggle(EV:AZURE_CASE_VALIDATION_FTA_ENABLED=on)
+@FeatureToggle(EV:PCS_CASE_VALIDATION_FTA_ENABLED=on)
 Feature: F-022 : Create Case Role Assignments for POSSESSIONS STAFF case roles
 
   Background:

--- a/src/functionalTest/resources/features/F-023 - Create POSSESSIONS CHALLENGED Case Role Assignments/F-023.feature
+++ b/src/functionalTest/resources/features/F-023 - Create POSSESSIONS CHALLENGED Case Role Assignments/F-023.feature
@@ -1,5 +1,6 @@
 @F-023
 @FeatureToggle(EV:AZURE_CASE_VALIDATION_FTA_ENABLED=on)
+@FeatureToggle(EV:PCS_CASE_VALIDATION_FTA_ENABLED=on)
 Feature: F-023 : Create Case Role Assignments for POSSESSIONS Challenged Access case roles
 
   Background:


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSAM-1273](https://tools.hmcts.net/jira/browse/DTSAM-1273) _"Disable PCS case-role FTAs in RAS until AAT instance is stable"_

### Change description ###

Temporarily disabled the PCS case-role functional tests until there is a stable PCS environment in AAT to run these tests against.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
