### PR TITLE
COT-1210: Fix case-allocator case role with Classification

### DIFF
--- a/src/main/resources/roleconfig/role_common.json
+++ b/src/main/resources/roleconfig/role_common.json
@@ -70,7 +70,10 @@
           "values": ["SPECIFIC"]
         },
         "classification": {
-          "mandatory": true
+          "mandatory": true,
+          "values": [
+            "RESTRICTED"
+          ]
         },
         "attributes": {
           "jurisdiction": {
@@ -235,7 +238,10 @@
           "values": ["SPECIFIC"]
         },
         "classification": {
-          "mandatory": true
+          "mandatory": true,
+          "values": [
+            "RESTRICTED"
+          ]
         },
         "attributes": {
           "jurisdiction": {
@@ -586,7 +592,10 @@
           "values": ["SPECIFIC"]
         },
         "classification": {
-          "mandatory": true
+          "mandatory": true,
+          "values": [
+            "RESTRICTED"
+          ]
         },
         "attributes": {
           "jurisdiction": {

--- a/src/main/resources/validationrules/fr/common/fr-case-role-validation.drl
+++ b/src/main/resources/validationrules/fr/common/fr-case-role-validation.drl
@@ -2,11 +2,12 @@ package validationrules.fr.common;
 import uk.gov.hmcts.reform.roleassignment.domain.model.Assignment;
 import uk.gov.hmcts.reform.roleassignment.domain.model.RoleAssignment;
 import uk.gov.hmcts.reform.roleassignment.domain.model.Request;
+import uk.gov.hmcts.reform.roleassignment.domain.model.enums.Classification;
 import uk.gov.hmcts.reform.roleassignment.domain.model.enums.Status;
 import uk.gov.hmcts.reform.roleassignment.domain.model.enums.RequestType;
 import uk.gov.hmcts.reform.roleassignment.domain.model.enums.GrantType;
 import uk.gov.hmcts.reform.roleassignment.domain.model.enums.RoleCategory;
-import uk.gov.hmcts.reform.roleassignment.domain.model.enums.RoleType
+import uk.gov.hmcts.reform.roleassignment.domain.model.enums.RoleType;
 import uk.gov.hmcts.reform.roleassignment.domain.model.ExistingRoleAssignment;
 import uk.gov.hmcts.reform.roleassignment.domain.model.CaseAllocatorApproval;
 import uk.gov.hmcts.reform.roleassignment.domain.model.Case;
@@ -30,6 +31,8 @@ when
                  roleAssignment.status == Status.CREATE_REQUESTED,
                  roleAssignment.attributes["jurisdiction"].asText() == "DIVORCE",
                  roleAssignment.attributes["caseType"].asText() == "FinancialRemedyMVP2",
+                 roleAssignment.classification == Classification.RESTRICTED,
+                 roleAssignment.grantType == GrantType.SPECIFIC,
                  roleAssignment.roleName == "case-allocator")
          ExistingRoleAssignment(
                  actorId == $ca.roleAssignment.actorId,

--- a/src/test/java/uk/gov/hmcts/reform/roleassignment/domain/service/drools/CaseRolesDroolsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/roleassignment/domain/service/drools/CaseRolesDroolsTest.java
@@ -745,6 +745,35 @@ class CaseRolesDroolsTest extends DroolBase {
                                               REJECTED);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        // FR case-allocator case role must be RESTRICTED (Confluence 4.2.3)
+        "DIVORCE,FinancialRemedyMVP2,case-allocator,JUDICIAL,PUBLIC,case-allocator",
+        "DIVORCE,FinancialRemedyMVP2,case-allocator,JUDICIAL,PRIVATE,case-allocator",
+        "DIVORCE,FinancialRemedyMVP2,case-allocator,ADMIN,PUBLIC,case-allocator",
+        "DIVORCE,FinancialRemedyMVP2,case-allocator,ADMIN,PRIVATE,case-allocator",
+        "DIVORCE,FinancialRemedyMVP2,case-allocator,CTSC,PUBLIC,case-allocator",
+        "DIVORCE,FinancialRemedyMVP2,case-allocator,CTSC,PRIVATE,case-allocator",
+    })
+    void shouldRejectAccessFor_FrCaseAllocator_NonRestrictedClassification(String jurisdiction,
+                                                                           String caseType,
+                                                                           String roleName,
+                                                                           String roleCategory,
+                                                                           String classification,
+                                                                           String existingRoleName) {
+        verifyGrantOrRejectAccessFor_CaseRole(jurisdiction,
+                                              caseType,
+                                              roleName,
+                                              roleCategory,
+                                              classification,
+                                              existingRoleName,
+                                              caseType,
+                                              null,
+                                              null,
+                                              null,
+                                              REJECTED);
+    }
+
     private void verifyGrantOrRejectAccessFor_CaseRole(String jurisdiction, String caseType, String roleName,
                                                        String roleCategory, String classification,
                                                        String existingRoleName, String existingCaseType,


### PR DESCRIPTION
### JIRA link (if applicable) ###

[COT-1210](https://tools.hmcts.net/jira/browse/COT-1210) "FR - DIVORCE_WA - Add CASE role validation drool rules in RAS application for STAFF And JUDICIARY"

### Change description ###

Fix case-allocator case role with Classification

This is a PATCH to the feature branch PR: 
* #2733


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
